### PR TITLE
Add test for component loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 venv
 *.pyc
 *.egg-info
+.eggs

--- a/flask_meld/__init__.py
+++ b/flask_meld/__init__.py
@@ -30,6 +30,14 @@ class Meld():
         app.jinja_env.add_extension(MeldScriptsExtension)
         app.socketio = SocketIO(app)
 
+        meld_dir = app.config.get("MELD_COMPONENT_DIR", None)
+        if meld_dir:
+            if not os.path.isabs(meld_dir):
+                directory = os.path.abspath(os.path.join(
+                    app.root_path, meld_dir))
+                print(directory)
+                app.config["MELD_COMPONENT_DIR"] = directory
+
         if not app.config.get('SECRET_KEY'):
             raise RuntimeError(
                 "The Flask-Meld requires the 'SECRET_KEY' config "

--- a/flask_meld/__init__.py
+++ b/flask_meld/__init__.py
@@ -35,7 +35,6 @@ class Meld():
             if not os.path.isabs(meld_dir):
                 directory = os.path.abspath(os.path.join(
                     app.root_path, meld_dir))
-                print(directory)
                 app.config["MELD_COMPONENT_DIR"] = directory
 
         if not app.config.get('SECRET_KEY'):

--- a/flask_meld/component.py
+++ b/flask_meld/component.py
@@ -23,6 +23,14 @@ def convert_to_camel_case(s):
 
 def get_component_class(component_name):
     module_name = convert_to_snake_case(component_name)
+    class_name = convert_to_camel_case(module_name)
+    module = get_component_module(module_name)
+    component_class = getattr(module, class_name)
+
+    return component_class
+
+
+def get_component_module(module_name):
     user_specified_dir = current_app.config.get("MELD_COMPONENT_DIR", None)
 
     if not user_specified_dir:
@@ -46,11 +54,7 @@ def get_component_class(component_name):
             spec = spec_from_file_location(module_name, full_path)
             module = module_from_spec(spec)
             spec.loader.exec_module(module)
-
-    class_name = convert_to_camel_case(module_name)
-    component_class = getattr(module, class_name)
-
-    return component_class
+        return module
 
 
 class Component:

--- a/flask_meld/component.py
+++ b/flask_meld/component.py
@@ -41,6 +41,7 @@ def get_component_module(module_name):
             )
         except ModuleNotFoundError:
             module = importlib.import_module(f"meld.components.{module_name}")
+        return module
     else:
         try:
             full_path = os.path.join(user_specified_dir, module_name + ".py")

--- a/flask_meld/component.py
+++ b/flask_meld/component.py
@@ -1,7 +1,8 @@
 import importlib
 import inspect
 import uuid
-from importlib.util import spec_from_loader, module_from_spec
+import os
+from importlib.util import module_from_spec, spec_from_file_location
 import importlib.machinery
 
 import orjson
@@ -34,17 +35,17 @@ def get_component_class(component_name):
             module = importlib.import_module(f"meld.components.{module_name}")
     else:
         try:
-            full_path = str(user_specified_dir.join(module_name + ".py"))
-            loader = importlib.machinery.SourceFileLoader(
-                module_name, full_path
-            )
-            spec = spec_from_loader(loader.name, loader)
+            full_path = os.path.join(user_specified_dir, module_name + ".py")
+            spec = spec_from_file_location(module_name, full_path)
             module = module_from_spec(spec)
-            loader.exec_module(module)
+            spec.loader.exec_module(module)
         except FileNotFoundError:
-            module = importlib.import_module(
-                f"{user_specified_dir}.components.{module_name}"
+            full_path = os.path.join(
+                user_specified_dir, "components",  module_name + ".py"
             )
+            spec = spec_from_file_location(module_name, full_path)
+            module = module_from_spec(spec)
+            spec.loader.exec_module(module)
 
     class_name = convert_to_camel_case(module_name)
     component_class = getattr(module, class_name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+import pytest
+from flask import Flask
+from flask_meld import Meld
+
+
+@pytest.fixture(scope='module')
+def app(tmpdir_factory):
+    app_dir = tmpdir_factory.mktemp('app')
+    app_dir = app_dir.mkdir('meld').mkdir('components')
+    module = app_dir.join("search.py")
+    with module.open('w') as f:
+        class_def = ["from flask_meld.component import Component",
+                     "class Search(Component):",
+                     "\tstate=''"]
+        f.writelines(f"{line}\n" for line in class_def)
+
+    meld = Meld()
+    app = Flask(__name__)
+    app.secret_key = __name__
+    app.config["MELD_COMPONENT_DIR"] = app_dir
+
+    meld.init_app(app)
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.yield_fixture
+def app_ctx(app):
+    with app.app_context() as ctx:
+        yield ctx

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,17 +3,21 @@ from flask import Flask
 from flask_meld import Meld
 
 
+def write_component_class_contents(component_file):
+    with component_file.open('w') as f:
+        class_def = ["from flask_meld.component import Component",
+                     "class Search(Component):",
+                     "\tstate=''"]
+        f.writelines(f"{line}\n" for line in class_def)
+
+
 @pytest.fixture(scope='module')
 def app(tmpdir_factory):
     # create directory structure of project/meld/components
     app_dir = tmpdir_factory.mktemp('meld')
     app_dir.mkdir('components')
-    module = app_dir.join("search.py")
-    with module.open('w') as f:
-        class_def = ["from flask_meld.component import Component",
-                     "class Search(Component):",
-                     "\tstate=''"]
-        f.writelines(f"{line}\n" for line in class_def)
+    component = app_dir.join("search.py")
+    write_component_class_contents(component)
 
     meld = Meld()
     app = Flask(__name__)
@@ -28,12 +32,8 @@ def app_factory(tmpdir_factory):
     # create directory structure of project/app/meld/components
     app_dir = tmpdir_factory.mktemp('app')
     app_dir = app_dir.mkdir('meld').mkdir('components')
-    module = app_dir.join("search.py")
-    with module.open('w') as f:
-        class_def = ["from flask_meld.component import Component",
-                     "class Search(Component):",
-                     "\tstate=''"]
-        f.writelines(f"{line}\n" for line in class_def)
+    component = app_dir.join("search.py")
+    write_component_class_contents(component)
 
     meld = Meld()
     app = Flask(__name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,27 @@ from flask_meld import Meld
 
 @pytest.fixture(scope='module')
 def app(tmpdir_factory):
+    # create directory structure of project/meld/components
+    app_dir = tmpdir_factory.mktemp('meld')
+    app_dir.mkdir('components')
+    module = app_dir.join("search.py")
+    with module.open('w') as f:
+        class_def = ["from flask_meld.component import Component",
+                     "class Search(Component):",
+                     "\tstate=''"]
+        f.writelines(f"{line}\n" for line in class_def)
+
+    meld = Meld()
+    app = Flask(__name__)
+    app.config["MELD_COMPONENT_DIR"] = app_dir
+    app.secret_key = __name__
+    meld.init_app(app)
+    return app
+
+
+@pytest.fixture(scope='module')
+def app_factory(tmpdir_factory):
+    # create directory structure of project/app/meld/components
     app_dir = tmpdir_factory.mktemp('app')
     app_dir = app_dir.mkdir('meld').mkdir('components')
     module = app_dir.join("search.py")
@@ -24,8 +45,14 @@ def app(tmpdir_factory):
 
 
 @pytest.fixture
-def client(app):
-    return app.test_client()
+def client(app_factory):
+    return app_factory.test_client()
+
+
+@pytest.yield_fixture
+def app_factory_ctx(app_factory):
+    with app_factory.app_context() as ctx:
+        yield ctx
 
 
 @pytest.yield_fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,13 +49,13 @@ def client(app_factory):
     return app_factory.test_client()
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def app_factory_ctx(app_factory):
     with app_factory.app_context() as ctx:
         yield ctx
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def app_ctx(app):
     with app.app_context() as ctx:
         yield ctx

--- a/tests/test_meld.py
+++ b/tests/test_meld.py
@@ -1,0 +1,6 @@
+from flask_meld.component import get_component_class
+
+
+def test_module_load_with_app_factory(app_ctx):
+    component_class = get_component_class("search")
+    assert component_class.__name__ == "Search"

--- a/tests/test_meld.py
+++ b/tests/test_meld.py
@@ -1,3 +1,4 @@
+import pytest
 from flask_meld.component import get_component_class
 
 
@@ -9,3 +10,20 @@ def test_module_load_with_app_factory(app_factory_ctx):
 def test_module_load_with_single_file_app(app_ctx):
     component_class = get_component_class("search")
     assert component_class.__name__ == "Search"
+
+
+def test_module_load_exception_with_single_file_app(app_ctx):
+    with pytest.raises(FileNotFoundError):
+        get_component_class("non-existant-module")
+
+
+def test_module_load_exception_with_app_factory(app_factory_ctx):
+    with pytest.raises(FileNotFoundError):
+        get_component_class("non-existant-module")
+
+
+def test_module_load_exception_without_user_specified_dir(app):
+    app.config["MELD_COMPONENT_DIR"] = None
+    with app.app_context():
+        with pytest.raises(ModuleNotFoundError):
+            get_component_class("non-existant-module")

--- a/tests/test_meld.py
+++ b/tests/test_meld.py
@@ -1,6 +1,11 @@
 from flask_meld.component import get_component_class
 
 
-def test_module_load_with_app_factory(app_ctx):
+def test_module_load_with_app_factory(app_factory_ctx):
+    component_class = get_component_class("search")
+    assert component_class.__name__ == "Search"
+
+
+def test_module_load_with_single_file_app(app_ctx):
     component_class = get_component_class("search")
     assert component_class.__name__ == "Search"


### PR DESCRIPTION
This tests that components will be loaded for different types of project structures. The one requirement is there should be a 'meld/components/' folder. The user can specify this location with a config variable via `MELD_COMPONENT_DIR`.

I am not sure the best way to test this. Using the pytest `tmpdir_factory` fixture works as long as the MELD_COMPONENT_DIR is set. Would it make sense to create a full project structure within the test directory? 
Examples:
`Flask-Meld/tests/TestProject/meld/components/search.py`
`Flask-Meld/tests/TestProjectFactory/app/meld/components/search.py`
