### PR TITLE
Use flask root_path for path references

### DIFF
--- a/flask_meld/component.py
+++ b/flask_meld/component.py
@@ -43,13 +43,11 @@ def get_component_module(module_name):
 
     if not user_specified_dir:
         try:
-            name = getattr(current_app, "name", None)
-            full_path = os.path.join(name, "meld", "components", module_name + ".py")
+            full_path = os.path.join(current_app.root_path, "meld", "components", module_name + ".py")
             module = load_module_from_path(full_path, module_name)
         except FileNotFoundError:
             full_path = os.path.join("meld", "components", module_name + ".py")
             module = load_module_from_path(full_path, module_name)
-        return module
     else:
         try:
             full_path = os.path.join(user_specified_dir, module_name + ".py")
@@ -59,7 +57,7 @@ def get_component_module(module_name):
                 user_specified_dir, "components", module_name + ".py"
             )
             module = load_module_from_path(full_path, module_name)
-        return module
+    return module
 
 
 def load_module_from_path(full_path, module_name):

--- a/flask_meld/meld.py
+++ b/flask_meld/meld.py
@@ -29,7 +29,7 @@ class Meld:
         # Load templates from template dir or app/meld/templates
         custom_template_loader = jinja2.ChoiceLoader([
             app.jinja_loader,
-            jinja2.FileSystemLoader('app/meld/templates'),
+            jinja2.FileSystemLoader(os.path.join(app.root_path, 'meld/templates')),
         ])
 
         app.jinja_loader = custom_template_loader

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ def app(tmpdir_factory):
     # create directory structure of project/meld/components
     app_dir = tmpdir_factory.mktemp("project")
     meld = Meld()
-    app = Flask(f"{app_dir}")
+    app = Flask(f"{app_dir}", root_path=app_dir)
     create_test_component(app_dir)
     app.secret_key = __name__
     meld.init_app(app)


### PR DESCRIPTION
This change will reduce the dependence on the working directory, which will improve the usage of flask-meld in existing projects and in setups that look slightly different then the generated one.