### PR TITLE
Test refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ venv
 tests/meld_test_project/meld/components
 tests/meld_test_project/meld/templates
 tests/meld_test_project/templates/index.html
+tests/meld_test_project/

--- a/README.md
+++ b/README.md
@@ -28,11 +28,7 @@ playwright install
 ### Run with browser tests
 
 ```sh
-# run the application on port 5009 without reload
-export FLASK_ENV=development
-cd tests/meld_test_project; flask run --port=5009 --no-reload
-
-# run tests in another terminal
+# run tests
 pytest
 
 # to watch the browser tests
@@ -44,4 +40,3 @@ pytest --headed
 ```sh
 pytest --ignore=tests/browser
 ```
-

--- a/tests/browser/databinding/debounce/debounce.html
+++ b/tests/browser/databinding/debounce/debounce.html
@@ -1,21 +1,21 @@
 <div>
     <h1>Test databinding debounce</h1>
-    <input id="input" meld:model.debounce-200="first_name">
+    <input id="input" meld:model.debounce-300="first_name">
         </br>
         <div id="bound-data">
             {{ first_name }}
         </div>
     <div>
-        <input id="foo-id" type="checkbox" meld:model.debounce-200="foo" >
+        <input id="foo-id" type="checkbox" meld:model.debounce-300="foo" >
         <span id="bound-foo">{{ foo }}</span>
 
-        <input id="bar-a" type="checkbox" meld:model.debounce-200="bar" value="q">
-        <input id="bar-b" type="checkbox" meld:model.debounce-200="bar" value="v">
-        <input id="bar-c" type="checkbox" meld:model.debounce-200="bar" value="c">
+        <input id="bar-a" type="checkbox" meld:model.debounce-300="bar" value="q">
+        <input id="bar-b" type="checkbox" meld:model.debounce-300="bar" value="v">
+        <input id="bar-c" type="checkbox" meld:model.debounce-300="bar" value="c">
 
         <span id="bound-bar">{{ bar }}</span>
 
-        <input id="baz-id" type="checkbox" meld:model:debounce="baz" value="2">
+        <input id="baz-id" type="checkbox" meld:model:debounce-300="baz" value="2">
         <span id="bound-baz">{{ baz }}</span>
     </div>
 </div>

--- a/tests/browser/databinding/debounce/test_debounce.py
+++ b/tests/browser/databinding/debounce/test_debounce.py
@@ -1,5 +1,10 @@
+import pytest
+from flask import url_for
+
+
+@pytest.mark.usefixtures('live_server')
 def test_input_debounce(browser_client, page):
-    page.goto("http://127.0.0.1:5009/")
+    page.goto(url_for('index', _external=True))
     # Click input
     page.click("input")
     # Fill input
@@ -11,8 +16,9 @@ def test_input_debounce(browser_client, page):
     assert page.inner_text('#bound-data') == 'flask-debounce test'
 
 
-def test_checkbox(browser_client, page):
-    page.goto("http://127.0.0.1:5009/")
+@pytest.mark.usefixtures('live_server')
+def test_checkbox_debounce(browser_client, page):
+    page.goto(url_for('index', _external=True))
     foo_id = "#foo-id"
     foo = page.locator("#foo-id")
 
@@ -30,10 +36,11 @@ def test_checkbox(browser_client, page):
     page.check("#bar-a")
     page.wait_for_timeout(200)
     assert page.inner_text("#bound-bar") == "[]"
-    page.check("#bar-b")
-    page.wait_for_timeout(100)
-    assert page.inner_text("#bound-bar") == "['q']"
     page.wait_for_timeout(200)
+    assert page.inner_text("#bound-bar") == "['q']"
+    page.check("#bar-b")
+    assert page.inner_text("#bound-bar") == "['q']"
+    page.wait_for_timeout(300)
     assert page.inner_text("#bound-bar") == "['q', 'v']"
 
     # test checkbox with int value

--- a/tests/browser/databinding/default/test_default.py
+++ b/tests/browser/databinding/default/test_default.py
@@ -1,65 +1,80 @@
-def test_input_text(browser_client, page):
-    page.goto("http://127.0.0.1:5009/")
+import pytest
+from flask import url_for, render_template, render_template_string
+
+
+def test_input_text(live_server, page, browser_client):
+    @live_server.app.route('/load-data')
+    def get_endpoint():
+        return render_template_string("""
+    {% extends "base.html" %}
+    {% block content %}
+    {% meld 'default' %}{% endblock %}
+    """, _external=True)
+
+    live_server.start()
+    # page.goto(url_for('index', _external=True))
+    page.goto(url_for('get_endpoint', _external=True))
+    # page.goto("http://127.0.0.1:5009/")
     # Click input
     page.click("#input")
     # Fill input
     fill_text = "flask-meld input_text"
     page.fill("input", fill_text)
-    page.wait_for_timeout(200)
+    page.wait_for_timeout(2000)
     assert page.inner_text("#bound-data-input") == fill_text
 
-    # make sure the text in the input does not disappear
-    assert page.input_value("#input") == fill_text
+    # # make sure the text in the input does not disappear
+    # assert page.input_value("#input") == fill_text
 
 
-def test_text_area(browser_client, page):
-    page.goto("http://127.0.0.1:5009/")
-    # Click text area
-    page.click("#text-area")
-    # Fill input
-    fill_text = "flask-meld textarea input"
-    page.fill("#text-area", fill_text)
-    page.wait_for_timeout(200)
-    assert page.inner_text("#bound-data-textarea") == fill_text
-
-    # make sure the text in the input does not disappear
-    assert page.input_value("#text-area") == fill_text
-
-
-def test_checkbox(browser_client, page):
-    page.goto("http://127.0.0.1:5009/")
-    foo_id = "#foo-id"
-    foo = page.locator("#foo-id")
-
-    assert page.inner_text("#bound-foo") == 'True'
-    assert foo.is_checked()
-
-    page.uncheck(foo_id)
-    page.wait_for_timeout(200)
-
-    assert foo.is_checked() is False
-    assert page.inner_text("#bound-foo") == 'False'
-
-    # test_multiple_checkboxes
-    page.check("#bar-a")
-    page.wait_for_timeout(200)
-    page.check("#bar-b")
-    page.wait_for_timeout(200)
-    assert page.inner_text("#bound-bar") == "['q', 'v']"
-
-    # test checkbox with int value
-    page.check("#baz-id")
-    page.wait_for_timeout(200)
-    assert page.inner_text("#bound-baz") == "2"
-
-
-def test_radio_field(browser_client, page):
-    page.goto("http://127.0.0.1:5009/")
-    page.click("#html")
-    page.wait_for_timeout(200)
-
-    assert page.inner_text("#bound-radio") == 'HTML'
-
-    page.click("#python")
-    page.wait_for_timeout(200)
-    assert page.inner_text("#bound-radio") == 'Python'
+# def test_text_area(browser_client, page):
+#     page.goto("http://127.0.0.1:5009/")
+#     # Click text area
+#     page.click("#text-area")
+#     # Fill input
+#     fill_text = "flask-meld textarea input"
+#     page.fill("#text-area", fill_text)
+#     page.wait_for_timeout(200)
+#     assert page.inner_text("#bound-data-textarea") == fill_text
+#
+#     # make sure the text in the input does not disappear
+#     assert page.input_value("#text-area") == fill_text
+#
+#
+# def test_checkbox(browser_client, page):
+#     page.goto("http://127.0.0.1:5009/")
+#     foo_id = "#foo-id"
+#     foo = page.locator(foo_id)
+#
+#     assert page.inner_text("#bound-foo") == 'True'
+#     assert foo.is_checked()
+#
+#     page.uncheck(foo_id)
+#     page.wait_for_timeout(200)
+#
+#     assert foo.is_checked() is False
+#     assert page.inner_text("#bound-foo") == 'False'
+#
+#     # test_multiple_checkboxes
+#     page.check("#bar-a")
+#     page.wait_for_timeout(200)
+#     page.check("#bar-b")
+#     page.wait_for_timeout(200)
+#     assert page.inner_text("#bound-bar") == "['q', 'v']"
+#
+#     # test checkbox with int value
+#     page.check("#baz-id")
+#     page.wait_for_timeout(200)
+#     assert page.inner_text("#bound-baz") == "2"
+#
+#
+# def test_radio_field(browser_client, page):
+#     page.goto("http://127.0.0.1:5009/")
+#     page.click("#html")
+#     page.wait_for_timeout(200)
+#
+#     assert page.inner_text("#bound-radio") == 'HTML'
+#
+#     page.click("#python")
+#     page.wait_for_timeout(200)
+#     assert page.inner_text("#bound-radio") == 'Python'

--- a/tests/browser/databinding/default/test_default.py
+++ b/tests/browser/databinding/default/test_default.py
@@ -2,79 +2,72 @@ import pytest
 from flask import url_for, render_template, render_template_string
 
 
-def test_input_text(live_server, page, browser_client):
-    @live_server.app.route('/load-data')
-    def get_endpoint():
-        return render_template_string("""
-    {% extends "base.html" %}
-    {% block content %}
-    {% meld 'default' %}{% endblock %}
-    """, _external=True)
-
-    live_server.start()
-    # page.goto(url_for('index', _external=True))
-    page.goto(url_for('get_endpoint', _external=True))
-    # page.goto("http://127.0.0.1:5009/")
+@pytest.mark.usefixtures('live_server')
+def test_input_text(page, browser_client):
+    page.goto(url_for('index', _external=True))
     # Click input
     page.click("#input")
     # Fill input
     fill_text = "flask-meld input_text"
     page.fill("input", fill_text)
-    page.wait_for_timeout(2000)
+    page.wait_for_timeout(200)
     assert page.inner_text("#bound-data-input") == fill_text
 
-    # # make sure the text in the input does not disappear
-    # assert page.input_value("#input") == fill_text
+    # make sure the text in the input does not disappear
+    assert page.input_value("#input") == fill_text
 
 
-# def test_text_area(browser_client, page):
-#     page.goto("http://127.0.0.1:5009/")
-#     # Click text area
-#     page.click("#text-area")
-#     # Fill input
-#     fill_text = "flask-meld textarea input"
-#     page.fill("#text-area", fill_text)
-#     page.wait_for_timeout(200)
-#     assert page.inner_text("#bound-data-textarea") == fill_text
-#
-#     # make sure the text in the input does not disappear
-#     assert page.input_value("#text-area") == fill_text
-#
-#
-# def test_checkbox(browser_client, page):
-#     page.goto("http://127.0.0.1:5009/")
-#     foo_id = "#foo-id"
-#     foo = page.locator(foo_id)
-#
-#     assert page.inner_text("#bound-foo") == 'True'
-#     assert foo.is_checked()
-#
-#     page.uncheck(foo_id)
-#     page.wait_for_timeout(200)
-#
-#     assert foo.is_checked() is False
-#     assert page.inner_text("#bound-foo") == 'False'
-#
-#     # test_multiple_checkboxes
-#     page.check("#bar-a")
-#     page.wait_for_timeout(200)
-#     page.check("#bar-b")
-#     page.wait_for_timeout(200)
-#     assert page.inner_text("#bound-bar") == "['q', 'v']"
-#
-#     # test checkbox with int value
-#     page.check("#baz-id")
-#     page.wait_for_timeout(200)
-#     assert page.inner_text("#bound-baz") == "2"
-#
-#
-# def test_radio_field(browser_client, page):
-#     page.goto("http://127.0.0.1:5009/")
-#     page.click("#html")
-#     page.wait_for_timeout(200)
-#
-#     assert page.inner_text("#bound-radio") == 'HTML'
-#
-#     page.click("#python")
-#     page.wait_for_timeout(200)
-#     assert page.inner_text("#bound-radio") == 'Python'
+@pytest.mark.usefixtures('live_server')
+def test_text_area(browser_client, page):
+    page.goto(url_for('index', _external=True))
+    # Click text area
+    page.click("#text-area")
+    # Fill input
+    fill_text = "flask-meld textarea input"
+    page.fill("#text-area", fill_text)
+    page.wait_for_timeout(200)
+    assert page.inner_text("#bound-data-textarea") == fill_text
+
+    # make sure the text in the input does not disappear
+    assert page.input_value("#text-area") == fill_text
+
+
+@pytest.mark.usefixtures('live_server')
+def test_checkbox(browser_client, page):
+    page.goto(url_for('index', _external=True))
+    foo_id = "#foo-id"
+    foo = page.locator(foo_id)
+
+    assert page.inner_text("#bound-foo") == 'True'
+    assert foo.is_checked()
+
+    page.uncheck(foo_id)
+    page.wait_for_timeout(200)
+
+    assert foo.is_checked() is False
+    assert page.inner_text("#bound-foo") == 'False'
+
+    # test_multiple_checkboxes
+    page.check("#bar-a")
+    page.wait_for_timeout(200)
+    page.check("#bar-b")
+    page.wait_for_timeout(200)
+    assert page.inner_text("#bound-bar") == "['q', 'v']"
+
+    # test checkbox with int value
+    page.check("#baz-id")
+    page.wait_for_timeout(200)
+    assert page.inner_text("#bound-baz") == "2"
+
+
+@pytest.mark.usefixtures('live_server')
+def test_radio_field(browser_client, page):
+    page.goto(url_for('index', _external=True))
+    page.click("#html")
+    page.wait_for_timeout(200)
+
+    assert page.inner_text("#bound-radio") == 'HTML'
+
+    page.click("#python")
+    page.wait_for_timeout(200)
+    assert page.inner_text("#bound-radio") == 'Python'

--- a/tests/browser/databinding/default/test_default.py
+++ b/tests/browser/databinding/default/test_default.py
@@ -1,5 +1,5 @@
 import pytest
-from flask import url_for, render_template, render_template_string
+from flask import url_for
 
 
 @pytest.mark.usefixtures('live_server')

--- a/tests/browser/databinding/defer/test_defer.py
+++ b/tests/browser/databinding/defer/test_defer.py
@@ -1,6 +1,10 @@
+import pytest
+from flask import url_for
+
+
+@pytest.mark.usefixtures('live_server')
 def test_input_defer(browser_client, page):
-    page.wait_for_timeout(500)
-    page.goto("http://127.0.0.1:5009/")
+    page.goto(url_for('index', _external=True))
     # Click input
     page.click("input")
     # Fill input
@@ -11,8 +15,9 @@ def test_input_defer(browser_client, page):
     assert page.inner_text('#bound-data-defer') == 'flask-defer test'
 
 
+@pytest.mark.usefixtures('live_server')
 def test_checkbox_defer(browser_client, page):
-    page.goto("http://127.0.0.1:5009/")
+    page.goto(url_for('index', _external=True))
     foo_id = "#foo-id"
     foo = page.locator("#foo-id")
 
@@ -41,9 +46,9 @@ def test_checkbox_defer(browser_client, page):
     # test checkbox with int value
     page.check("#baz-id")
     page.click("#button")
-    page.wait_for_timeout(100)
+    page.wait_for_timeout(50)
     assert page.inner_text("#bound-baz") == ""
-    page.wait_for_timeout(100)
+    page.wait_for_timeout(300)
     assert page.inner_text("#bound-baz") == "2"
 
     # test multiple checkboxes in same request

--- a/tests/browser/databinding/lazy/test_input_text_lazy.py
+++ b/tests/browser/databinding/lazy/test_input_text_lazy.py
@@ -1,5 +1,10 @@
+import pytest
+from flask import url_for
+
+
+@pytest.mark.usefixtures('live_server')
 def test_input_text(browser_client, page):
-    page.goto("http://127.0.0.1:5009/")
+    page.goto(url_for('index', _external=True))
     # wait for component.loaded
     # Click input
     page.click("input")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,16 +31,16 @@ def app():
     return app
 
 
-# @pytest.fixture(scope="module")
-# def app(tmpdir_factory):
-#     # create directory structure of project/meld/components
-#     app_dir = tmpdir_factory.mktemp("project")
-#     meld = Meld()
-#     app = Flask(f"{app_dir}", root_path=app_dir)
-#     create_test_component(app_dir)
-#     app.secret_key = __name__
-#     meld.init_app(app)
-#     return app
+@pytest.fixture(scope="module")
+def app_mod(tmpdir_factory):
+    # create directory structure of project/meld/components
+    app_dir = tmpdir_factory.mktemp("project")
+    meld = Meld()
+    app = Flask(f"{app_dir}", root_path=app_dir)
+    create_test_component(app_dir)
+    app.secret_key = __name__
+    meld.init_app(app)
+    return app
 
 
 @pytest.fixture(scope="session")
@@ -97,8 +97,8 @@ def app_factory_ctx(app_factory):
 
 
 @pytest.fixture
-def app_ctx(app):
-    with app.app_context() as ctx:
+def app_ctx(app_mod):
+    with app_mod.app_context() as ctx:
         yield ctx
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,14 @@
 import os
 import shutil
-import pytest
-from time import sleep
-from flask import Flask
-from flask_meld import Meld
+from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
-from importlib.util import spec_from_file_location, module_from_spec
+from time import sleep
+
+import pytest
+from flask import Flask
+from meld_test_project import create_app
+
+from flask_meld import Meld
 from flask_meld.cli import generate_meld_app
 
 
@@ -17,16 +20,27 @@ def init_app(app_dir):
     return app
 
 
-@pytest.fixture(scope="module")
-def app(tmpdir_factory):
-    # create directory structure of project/meld/components
-    app_dir = tmpdir_factory.mktemp("project")
-    meld = Meld()
-    app = Flask(f"{app_dir}", root_path=app_dir)
-    create_test_component(app_dir)
-    app.secret_key = __name__
-    meld.init_app(app)
+"""
+Can we pass in a test directory to the application?
+"""
+
+
+@pytest.fixture(scope="session")
+def app():
+    app = create_app()
     return app
+
+
+# @pytest.fixture(scope="module")
+# def app(tmpdir_factory):
+#     # create directory structure of project/meld/components
+#     app_dir = tmpdir_factory.mktemp("project")
+#     meld = Meld()
+#     app = Flask(f"{app_dir}", root_path=app_dir)
+#     create_test_component(app_dir)
+#     app.secret_key = __name__
+#     meld.init_app(app)
+#     return app
 
 
 @pytest.fixture(scope="session")
@@ -51,7 +65,7 @@ def app_factory(tmpdir_factory):
 @pytest.fixture(scope="function")
 def browser_client(pytestconfig):
     current_test = os.getenv('PYTEST_CURRENT_TEST')
-    base = pytestconfig.rootdir / "tests"
+    base = pytestconfig.rootdir
     meld_base = Path(f"{base}/meld_test_project/meld")
     index = Path(f"{base}/meld_test_project/templates/index.html")
 
@@ -60,7 +74,7 @@ def browser_client(pytestconfig):
 
     component_name_path = Path(current_test.split("::")[0].split(".")[0])
 
-    component_base_path = Path(base, "/".join(component_name_path.parts[1:-1]))
+    component_base_path = Path(base, "/".join(component_name_path.parts[:-1]))
     component_name = component_name_path.parts[-1].replace("test_", "")
 
     template = Path(f"{component_base_path}/{component_name}.html")

--- a/tests/meld_test_project/__init__.py
+++ b/tests/meld_test_project/__init__.py
@@ -1,6 +1,7 @@
 import secrets
 from flask import Flask, render_template
 from flask_meld import Meld
+from flask_socketio import SocketIO
 
 # extensions
 meld = Meld()
@@ -10,16 +11,12 @@ def create_app():
     app = Flask(__name__)
 
     app.config["SECRET_KEY"] = secrets.token_hex(16)
-
-    meld.init_app(app)
+    app.config["DEBUG"] = False
+    socketio = SocketIO(app, async_mode="threading")
+    meld.init_app(app, socketio)
 
     @app.route("/")
     def index():
         return render_template("index.html")
 
     return app
-
-
-if __name__ == "__main__":
-    app = create_app()
-    app.run(port=5001)

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+live_server_scope = function

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,7 @@
 -e ..
-Flask-WTF
 email_validator
+Flask-WTF
+playwright==1.17.0
 pytest==6.2.5
 pytest-playwright==0.2.2
-playwright==1.17.0
+pytest-flask==1.2.0


### PR DESCRIPTION
Refactor tests to use `pytest-flask` for liveserver. 

- No longer need to run local server for running browser tests
- Use `async_mode="threading"` for socketio